### PR TITLE
Allow to select panel to display lyrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,6 +168,14 @@
           "default": true,
           "description": "Whether to show lyrics button."
         },
+        "spotify.openPanelLyrics": {
+          "type": "number",
+          "default": 1,
+          "enum": [
+            1, 2, 3
+          ],
+          "description": "Panel to display the Lyrics"
+        },
         "spotify.priorityBase": {
           "type": "number",
           "default": 30,

--- a/src/config/SpotifyConfig.ts
+++ b/src/config/SpotifyConfig.ts
@@ -21,6 +21,10 @@ export function getLyricsServerUrl(): string {
 	return getConfig().get<string>('lyricsServerUrl', '');
 }
 
+export function openPanelLyrics(): number {
+	return getConfig().get<number>('openPanelLyrics', 1);
+}
+
 export function getUseCombinedApproachOnMacOS(): boolean {
 	return getConfig().get<boolean>('useCombinedApproachOnMacOS', false);
 }

--- a/src/lyrics/Lyrics.ts
+++ b/src/lyrics/Lyrics.ts
@@ -1,11 +1,12 @@
 import { SpotifyStatus } from '../SpotifyStatus';
 import { xhr } from '../request/Request';
-import { getLyricsServerUrl } from '../config/SpotifyConfig';
+import { getLyricsServerUrl, openPanelLyrics } from '../config/SpotifyConfig';
 import { showInformationMessage } from '../info/Info';
 import { Uri, TextDocumentContentProvider, EventEmitter, Event, window, workspace, ProgressLocation } from 'vscode';
 
 let previewUri = Uri.parse('vscode-spotify://authority/vscode-spotify');
 let html = '';
+
 class TextContentProvider implements TextDocumentContentProvider {
     private _onDidChange = new EventEmitter<Uri>();
 
@@ -24,13 +25,12 @@ class TextContentProvider implements TextDocumentContentProvider {
 
 let provider = new TextContentProvider();
 
-
 async function previewLyrics(lyrics: string) {
     html = lyrics.trim();
     provider.update(previewUri);
     try {
         const document = await workspace.openTextDocument(previewUri);
-        await window.showTextDocument(document);
+        await window.showTextDocument(document, openPanelLyrics(), true);
     } catch (_ignored) {
         showInformationMessage('Failed to show lyrics' + _ignored);
     }


### PR DESCRIPTION
### Description
Option to select the panel number to open the lyrics

### Issue
https://github.com/ShyykoSerhiy/vscode-spotify/issues/22

### Option
- *name*: spotify.openPanelLyrics
- *type*: number
- *default*: 1
- *possible values*: 1, 2, 3

