### PR TITLE
Feature: show album name

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,11 @@
       "type": "object",
       "title": "vscode-spotify configuration",
       "properties": {
+        "spotify.trackInfoFormat": {
+          "type": "string",
+          "default": "artistName - trackName - albumName",
+          "description": "Current track info that will be displayed. Available keywords: albumName, artistName,  trackName"
+        },
         "spotify.showNextButton": {
           "type": "boolean",
           "default": true,

--- a/src/SpotifyStatus.ts
+++ b/src/SpotifyStatus.ts
@@ -3,6 +3,7 @@ import {SpotifyControls} from './SpotifyControls';
 import {getButtonPriority} from './config/SpotifyConfig';
 
 export interface Track {
+    album: string,
     artist: string,
     name: string
 }
@@ -31,7 +32,7 @@ export class SpotifyStatus {
     private _statusBarItem: StatusBarItem;
     private _spotifyControls: SpotifyControls;
     /**
-     * 'Current'(last retrieved) state of spotify. 
+     * 'Current'(last retrieved) state of spotify.
      */
     private _state: SpotifyStatusState;
     private _hidden: boolean;
@@ -52,7 +53,7 @@ export class SpotifyStatus {
      * Updates spotify status bar inside vscode
      */
     public updateSpotifyStatus() {
-        // Create as needed 
+        // Create as needed
         if (!this._statusBarItem) {
             this._statusBarItem = window.createStatusBarItem(StatusBarAlignment.Left, getButtonPriority('trackInfoPriority'));
             this._statusBarItem.show();
@@ -64,11 +65,11 @@ export class SpotifyStatus {
 
         if (this._state.isRunning) {
             const {isRepeating, isShuffling} = this._state;
-            const {artist, name} = this._state.track;            
+            const {album, artist, name} = this._state.track;
             const {state: playing, volume} = this._state.state;
-            var text = `${artist} - ${name}`;
+            var text = `${artist} - ${name} - ${album}`;
             if (text !== this._statusBarItem.text) {//we need this guard to prevent flickering
-                this._statusBarItem.text = `${artist} - ${name}`;
+                this._statusBarItem.text = text;
                 this.redraw();//we need to redraw due to a bug with priority
             }
             if (this._spotifyControls.updateDynamicButtons(playing === 'playing', volume === 0, isRepeating, isShuffling)) {
@@ -91,7 +92,7 @@ export class SpotifyStatus {
             this._spotifyControls.hideAll();
             this._hidden = true;
         }
-    }  
+    }
     /**
      * True if on last state of Spotify it was muted(volume was equal 0)
      */

--- a/src/SpotifyStatus.ts
+++ b/src/SpotifyStatus.ts
@@ -1,6 +1,6 @@
 import {window, StatusBarItem, StatusBarAlignment} from 'vscode';
 import {SpotifyControls} from './SpotifyControls';
-import {getButtonPriority} from './config/SpotifyConfig';
+import {getTrackInfoFormat, getButtonPriority} from './config/SpotifyConfig';
 
 export interface Track {
     album: string,
@@ -65,9 +65,8 @@ export class SpotifyStatus {
 
         if (this._state.isRunning) {
             const {isRepeating, isShuffling} = this._state;
-            const {album, artist, name} = this._state.track;
             const {state: playing, volume} = this._state.state;
-            var text = `${artist} - ${name} - ${album}`;
+            var text = _formattedTrackInfo(this._state.track);
             if (text !== this._statusBarItem.text) {//we need this guard to prevent flickering
                 this._statusBarItem.text = text;
                 this.redraw();//we need to redraw due to a bug with priority
@@ -110,4 +109,17 @@ export class SpotifyStatus {
             this._spotifyControls
         }
     }
+}
+
+function _formattedTrackInfo(track: Track): string {
+    const { album, artist, name } = track;
+    const keywordsMap:{[index:string]: string} = {
+        albumName: album,
+        artistName: artist,
+        trackName: name,
+    }
+    let a = getTrackInfoFormat().replace(/albumName|artistName|trackName/gi, matched => {
+        return keywordsMap[matched];
+    });
+    return a;
 }

--- a/src/SpotifyStatusController.ts
+++ b/src/SpotifyStatusController.ts
@@ -41,7 +41,7 @@ export class SpotifyStatusController {
             if (this._retryCount >= this._maxRetryCount) {
                 this._spotifyStatus.state = {
                     state: { position: 0, volume: 0, state: '' },
-                    track: { artist: '', name: '' },
+                    track: { album: '', artist: '', name: '' },
                     isRepeating: false,
                     isShuffling: false,
                     isRunning: false
@@ -56,7 +56,7 @@ export class SpotifyStatusController {
             this._retryCount = 0;
         }, getStatusCheckInterval)
         this._cancelCb = cancel;
-        promise.catch(clearState);        
+        promise.catch(clearState);
     }
 
     dispose() {

--- a/src/config/SpotifyConfig.ts
+++ b/src/config/SpotifyConfig.ts
@@ -32,3 +32,7 @@ export function getUseCombinedApproachOnMacOS(): boolean {
 export function getShowInitializationError(): boolean {
 	return getConfig().get<boolean>('showInitializationError', false);
 }
+
+export function getTrackInfoFormat(): string {
+	return getConfig().get<string>('trackInfoFormat', '');
+}

--- a/src/spotify/OsAgnosticSpotifyClient.ts
+++ b/src/spotify/OsAgnosticSpotifyClient.ts
@@ -49,6 +49,7 @@ function convertSpotilocalStatus(spotilocalStatus: Status): SpotifyStatusState {
             state: spotilocalStatus.playing ? 'playing' : 'paused'
         },
         track: {
+            album: spotilocalStatus.track.album_resource.name,
             artist: spotilocalStatus.track.artist_resource.name,
             name: spotilocalStatus.track.track_resource.name
         },
@@ -65,7 +66,7 @@ export class OsAgnosticSpotifyClient implements SpotifyClient {
     private spotilocal: Spotilocal;
     private initialized: boolean;
     private showedReinitMessage: boolean;
-    private initTimeoutId: number;    
+    private initTimeoutId: number;
 
     constructor(spotifyStatus: SpotifyStatus, spotifyStatusController: SpotifyStatusController) {
         this.spotifyStatus = spotifyStatus;
@@ -75,7 +76,7 @@ export class OsAgnosticSpotifyClient implements SpotifyClient {
         this.retryInit();
     }
     private retryInit() {
-        this.initialized = false;        
+        this.initialized = false;
         this.initTimeoutId && clearTimeout(this.initTimeoutId);
         const lastUsedPort = this.spotifyStatusController.globalState.get<number>("lastUsedPort");
         this.spotilocal.init(lastUsedPort).then(() => {
@@ -86,7 +87,7 @@ export class OsAgnosticSpotifyClient implements SpotifyClient {
         }).catch((ignorredError) => {
             if (!this.showedReinitMessage && getShowInitializationError()) {
                 showInformationMessage('Failed to initialize vscode-spotify. We\'ll keep trying every 20 seconds.');
-            }            
+            }
             console.error('Failed to initialize vscode-spotify. We\'ll keep trying every 20 seconds.', ignorredError);
             this.showedReinitMessage = true;
             this.initTimeoutId = setTimeout(this.retryInit.bind(this), 20 * 1000);


### PR DESCRIPTION
This PR adds the album name to the track info status bar by default, and lets users overwrite the status bar format.

In order to overwrite the format:
```json
"spotify.trackInfoFormat": "artistName - trackName"
```

New default format:
```json
"spotify.trackInfoFormat": "artistName - trackName - albumName"
```

Accepted keywords: `albumName`, `artistName`, `trackName`.

This PR fixes #28.