### PR TITLE
fix: `trackInfoPriority` setting has no effect

### DIFF
--- a/src/SpotifyStatus.ts
+++ b/src/SpotifyStatus.ts
@@ -55,7 +55,7 @@ export class SpotifyStatus {
     public updateSpotifyStatus() {
         // Create as needed
         if (!this._statusBarItem) {
-            this._statusBarItem = window.createStatusBarItem(StatusBarAlignment.Left, getButtonPriority('trackInfoPriority'));
+            this._statusBarItem = window.createStatusBarItem(StatusBarAlignment.Left, getButtonPriority('trackInfo'));
             this._statusBarItem.show();
         }
         if (!this._spotifyControls) {


### PR DESCRIPTION
A typo in `SpotifyStatus.ts` prevented the `trackInfoPriority` setting to take effect.