### PR TITLE
Change default mac keybindings for play previous/next

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,12 +81,12 @@
       {
         "command": "spotify.next",
         "key": "ctrl+shift+]",
-        "mac": "cmd+shift+]"
+        "mac": "ctrl+cmd+]"
       },
       {
         "command": "spotify.previous",
         "key": "ctrl+shift+[",
-        "mac": "cmd+shift+["
+        "mac": "ctrl+cmd+["
       },
       {
         "command": "spotify.volumeUp",


### PR DESCRIPTION
Love this extension. It's a very neat idea. Unfortunately, I'm not as big of a fan of its default keybindings for `spotify.next` and `spotify.pevious`.

On Mac, these bindings are `cmd+shift+]` and `cmd+shift+[` respectively. These keybindings are quite universal as keybindings for cycling through tabs in basically all editors and browsers. At least in VSCode, there will be a conflict with `workbench.action.previousEditor` and `workbench.action.nextEditor`.  It is very odd for me to change my normal software development habits due to this extensions's defaults, so I immediately found myself wanting to change the Spotify keymappings instead.

My PR introduces what I find to be reasonable alternative defaults. I was not able to find other conflicting keymappings that matches `ctrl+cmd+[` or `ctrl+cmd+]`. It allows the square bracket characters to continue to be present in the keymappings, to directionally represent going forward or backwards in the playlist.

I'm not sure if the Windows keymapping needs to be changed too. I don't have a Windows machine, so I could not check whether a conflict exists between these Spotify keymappings and VSCode default keymappings for Windows. I'll leave it up to the maintainers to determine if a change needs to happen for that OS.

I hope this helps.