### PR TITLE
[FIX] Tooltip Missing Album Name in Tree Track

### DIFF
--- a/src/components/tree-track.ts
+++ b/src/components/tree-track.ts
@@ -91,7 +91,7 @@ class TrackTreeItem extends vscode.TreeItem {
 
 
 	get tooltip(): string {
-		return `${getArtists(this.track)} - ${this.track.track.album} - ${this.track.track.name}`
+		return `${getArtists(this.track)} - ${this.track.track.album.name} - ${this.track.track.name}`
 	}
 
 	iconPath = {


### PR DESCRIPTION
Before
<img src="https://user-images.githubusercontent.com/4416419/46583515-cb4a3f00-ca82-11e8-9b71-989d5200649a.png" alt="before" width="400" />

After
<img src="https://user-images.githubusercontent.com/4416419/46583477-4bbc7000-ca82-11e8-9b22-dd9bac111f4f.png" alt="after" width="400" />
