### PR TITLE
chore: add vscode-test to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_STORE
+.vscode-test
 
 # Logs
 logs


### PR DESCRIPTION
The `test` script in `package.json` downloads a `vscode-test` folder, which shouldn't be committed. So I added it to the `.gitignore`