### PR TITLE
feat: option for show signIn and signOut button

### DIFF
--- a/package.json
+++ b/package.json
@@ -232,6 +232,16 @@
           "default": true,
           "description": "Whether to show lyrics button."
         },
+        "spotify.showLyricsButtonSignInButton": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether to show sign in button."
+        },
+        "spotify.showLyricsButtonSignOutButton": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether to show sign out button."
+        },
         "spotify.openPanelLyrics": {
           "type": "number",
           "default": 1,

--- a/src/config/spotify-config.ts
+++ b/src/config/spotify-config.ts
@@ -8,15 +8,16 @@ export function getConfig() {
 }
 
 export function isButtonToBeShown(buttonId: string): boolean {
+	const shouldShow = getConfig().get('show' + buttonId[0].toUpperCase() + buttonId.slice(1), false);
 	const { loginState } = getState();
+
 	if (buttonId === `${BUTTON_ID_SIGN_IN}Button`) {
-		return !loginState;
-	}
-	if (buttonId === `${BUTTON_ID_SIGN_OUT}Button`) {
-		return !!loginState;
+		return shouldShow ? !loginState : false;
+	} else if (buttonId === `${BUTTON_ID_SIGN_OUT}Button`) {
+		return shouldShow ? !!loginState : false;
 	}
 
-	return getConfig().get('show' + buttonId[0].toUpperCase() + buttonId.slice(1), false);
+	return shouldShow;
 }
 
 export function getButtonPriority(buttonId: string): number {

--- a/src/config/spotify-config.ts
+++ b/src/config/spotify-config.ts
@@ -12,9 +12,9 @@ export function isButtonToBeShown(buttonId: string): boolean {
 	const { loginState } = getState();
 
 	if (buttonId === `${BUTTON_ID_SIGN_IN}Button`) {
-		return shouldShow ? !loginState : false;
+		return shouldShow && !loginState;
 	} else if (buttonId === `${BUTTON_ID_SIGN_OUT}Button`) {
-		return shouldShow ? !!loginState : false;
+		return shouldShow && !!loginState;
 	}
 
 	return shouldShow;


### PR DESCRIPTION
The new `signIn` and `signOut` buttons have a priority configuration but not a show/hide, this adds it. So the user can hide the button if he doesn't use it.