### PR TITLE
Add link to full options

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ You can change what buttons to show by changing parameters([go here to find out 
 }
 ```
 
+For the full configuration options go [here](https://github.com/ShyykoSerhiy/vscode-spotify/blob/master/package.json#L161).
+
 Note that due to limitations of Spotify's applesctipt API toggleRepeatingButton toggles only
 'repeat all' property of spotify. There is no way to set 'repeat one' via vscode-spotify.  
 


### PR DESCRIPTION
I'm not sure what it the best approach. This or put the full list in the readme. It's quite long.