### PR TITLE
fix: typings for osx are not applied for source files

### DIFF
--- a/src/spotify/osx-spotify-client.ts
+++ b/src/spotify/osx-spotify-client.ts
@@ -8,7 +8,7 @@ export class OsxSpotifyClient implements SpotifyClient {
     private _queryStatusFunc: QueryStatusFunction
 
     constructor(queryStatusFunc: QueryStatusFunction) {
-        this._queryStatusFunc = queryStatusFunc;        
+        this._queryStatusFunc = queryStatusFunc;
     }
     get queryStatusFunc() {
         return this._queryStatusFunc;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,9 +11,16 @@
 		"noUnusedParameters": true,
 		"strictNullChecks": true,
 		"experimentalDecorators": true,
-		"skipLibCheck": true
+		"skipLibCheck": true,
+		"alwaysStrict": true
 	},
+	"include": [
+        "src/**/*"
+    ],
 	"exclude": [
 		"node_modules"
-	]
+	],
+	"files": [
+        "typings/spotify-node-applescript.d.ts"
+    ]
 }


### PR DESCRIPTION
- Typings for `spotify-node-applescript` are created but they are not visible in the source files since not specified in `tsconfig.json` -- added that.
- Also added `alwaysStrict: true` to have strict compiling options enabled to all source files.
