### PR TITLE
fix: spotify controls are not getting disposed

### DIFF
--- a/src/components/spotify-status.ts
+++ b/src/components/spotify-status.ts
@@ -72,7 +72,7 @@ export class SpotifyStatus {
             this._statusBarItem.dispose();
         }
         if (this._spotifyControls) {
-            this._spotifyControls
+            this._spotifyControls.dispose();
         }
     }
 }


### PR DESCRIPTION
There is a missing `dispose()` call for spotify controls in `SpotifyStatus`'s `dispose()` method.