### PR TITLE
feat: create albums view

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,10 @@
           "name": "Playlists"
         },
         {
+          "id": "vscode-spotify-albums",
+          "name": "Albums"
+        },
+        {
           "id": "vscode-spotify-tracks",
           "name": "Tracks"
         }
@@ -114,6 +118,14 @@
         }
       },
       {
+        "command": "spotify.loadAlbums",
+        "title": "Spotify Load Albums",
+        "icon": {
+          "light": "resources/light/refresh.svg",
+          "dark": "resources/dark/refresh.svg"
+        }
+      },
+      {
         "command": "spotify.loadTracks",
         "title": "Spotify Load Tracks",
         "icon": {
@@ -157,6 +169,11 @@
         {
           "command": "spotify.loadPlaylists",
           "when": "view == vscode-spotify-playlists",
+          "group": "navigation"
+        },
+        {
+          "command": "spotify.loadAlbums",
+          "when": "view == vscode-spotify-albums",
           "group": "navigation"
         },
         {
@@ -401,17 +418,17 @@
     "contributors:check": "all-contributors check"
   },
   "devDependencies": {
+    "@types/cheerio": "^0.22.22",
     "@types/express": "^4.11.1",
     "@types/mocha": "^8.0.0",
     "@types/node": "^14.0.27",
     "@types/superagent": "^2.0.36",
     "@types/vscode": "^1.49.0",
-    "@types/cheerio": "^0.22.22",
-    "all-contributors-cli": "^6.17.4",
-    "typescript": "^4.0.2",
-    "eslint": "^7.9.0",
     "@typescript-eslint/eslint-plugin": "^4.1.1",
     "@typescript-eslint/parser": "^4.1.1",
+    "all-contributors-cli": "^6.17.4",
+    "eslint": "^7.9.0",
+    "typescript": "^4.0.2",
     "vscode-test": "^1.4.0"
   },
   "dependencies": {

--- a/src/actions/common.ts
+++ b/src/actions/common.ts
@@ -1,11 +1,13 @@
-import { Playlist, Track } from '@vscodespotify/spotify-common/lib/spotify/consts';
+import { Album, Playlist, Track } from '@vscodespotify/spotify-common/lib/spotify/consts';
 import { ISpotifyStatusState } from '../state/state';
 
 export const UPDATE_STATE_ACTION = 'UPDATE_STATE_ACTION' as 'UPDATE_STATE_ACTION';
 export const SIGN_IN_ACTION = 'SIGN_IN_ACTION' as 'SIGN_IN_ACTION';
 export const SIGN_OUT_ACTION = 'SIGN_OUT_ACTION' as 'SIGN_OUT_ACTION';
 export const PLAYLISTS_LOAD_ACTION = 'PLAYLISTS_LOAD_ACTION' as 'PLAYLISTS_LOAD_ACTION';
+export const ALBUM_LOAD_ACTION = 'ALBUM_LOAD_ACTION' as const;
 export const SELECT_PLAYLIST_ACTION = 'SELECT_PLAYLIST_ACTION' as 'SELECT_PLAYLIST_ACTION';
+export const SELECT_ALBUM_ACTION = 'SELECT_ALBUM_ACTION' as const;
 export const TRACKS_LOAD_ACTION = 'TRACKS_LOAD_ACTION' as 'TRACKS_LOAD_ACTION';
 export const SELECT_TRACK_ACTION = 'SELECT_TRACK_ACTION' as 'SELECT_TRACK_ACTION';
 
@@ -29,15 +31,25 @@ export interface PlaylistsLoadAction {
     playlists: Playlist[];
 }
 
+export interface AlbumLoadAction {
+    type: typeof ALBUM_LOAD_ACTION;
+    albums: Album[];
+}
+
 export interface TracksLoadAction {
     type: typeof TRACKS_LOAD_ACTION;
-    playlist: Playlist;
+    list: Playlist | Album;
     tracks: Track[];
 }
 
 export interface SelectPlaylistAction {
     type: typeof SELECT_PLAYLIST_ACTION;
     playlist: Playlist;
+}
+
+export interface SelectAlbumAction {
+    type: typeof SELECT_ALBUM_ACTION;
+    album: Album;
 }
 
 export interface SelectTrackAction {
@@ -49,6 +61,8 @@ export type Action = UpdateStateAction |
     SignInAction |
     SignOutAction |
     PlaylistsLoadAction |
+    AlbumLoadAction |
     SelectPlaylistAction |
+    SelectAlbumAction |
     TracksLoadAction |
-    SelectTrackAction; 
+    SelectTrackAction;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -4,7 +4,7 @@ import { actionsCreator } from './actions/actions';
 import { getTrackInfoClickBehaviour } from './config/spotify-config';
 import { LyricsController } from './lyrics/lyrics';
 import { SpotifyClient } from './spotify/common';
-import { Playlist } from './state/state';
+import { Album, Playlist } from './state/state';
 import { SIGN_IN_COMMAND } from './consts/consts';
 
 export function createCommands(sC: SpotifyClient): { dispose: () => void } {
@@ -26,6 +26,7 @@ export function createCommands(sC: SpotifyClient): { dispose: () => void } {
     const signIn = commands.registerCommand(SIGN_IN_COMMAND, actionsCreator.actionSignIn);
     const signOut = commands.registerCommand('spotify.signOut', actionsCreator.actionSignOut);
     const loadPlaylists = commands.registerCommand('spotify.loadPlaylists', actionsCreator.loadPlaylists);
+    const loadAlbums = commands.registerCommand('spotify.loadAlbums', actionsCreator.loadAlbums);
     const loadTracks = commands.registerCommand('spotify.loadTracks', actionsCreator.loadTracksForSelectedPlaylist);
     const trackInfoClick = commands.registerCommand('spotify.trackInfoClick', () => {
         const trackInfoClickBehaviour = getTrackInfoClickBehaviour();
@@ -35,8 +36,8 @@ export function createCommands(sC: SpotifyClient): { dispose: () => void } {
             sC.playPause();
         }
     });
-    const playTrack = commands.registerCommand('spotify.playTrack', async (/*arguments from TrackTreeItem event*/offset: number, playlist: Playlist) => {
-        await actionsCreator.playTrack(offset, playlist);
+    const playTrack = commands.registerCommand('spotify.playTrack', async (/*arguments from TrackTreeItem event*/offset: number, list: Playlist | Album) => {
+        await actionsCreator.playTrack(offset, list);
         sC.queryStatusFunc();
     });
     const seekTo = commands.registerCommand('spotify.seekTo', (seekToMs: string) => {
@@ -59,6 +60,7 @@ export function createCommands(sC: SpotifyClient): { dispose: () => void } {
         signIn,
         signOut,
         loadPlaylists,
+        loadAlbums,
         loadTracks,
         trackInfoClick,
         playTrack,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import { ExtensionContext, window } from 'vscode';
 import { createCommands } from './commands';
 import { SpotifyStatus } from './components/spotify-status';
 import { connectPlaylistTreeView, TreePlaylistProvider } from './components/tree-playlists';
+import { connectAlbumTreeView, TreeAlbumProvider } from './components/tree-albums';
 import { connectTrackTreeView, TreeTrackProvider } from './components/tree-track';
 import { registerGlobalState } from './config/spotify-config';
 import { SpotifyStatusController } from './spotify-status-controller';
@@ -18,11 +19,13 @@ export function activate(context: ExtensionContext) {
     const spotifyStatus = new SpotifyStatus();
     const controller = new SpotifyStatusController();
     const playlistTreeView = window.createTreeView('vscode-spotify-playlists', { treeDataProvider: new TreePlaylistProvider() });
+    const albumTreeView = window.createTreeView('vscode-spotify-albums', { treeDataProvider: new TreeAlbumProvider() });
     const treeTrackProvider = new TreeTrackProvider();
     const trackTreeView = window.createTreeView('vscode-spotify-tracks', { treeDataProvider: treeTrackProvider });
     treeTrackProvider.bindView(trackTreeView);
     // Add to a list of disposables which are disposed when this extension is deactivated.
     context.subscriptions.push(connectPlaylistTreeView(playlistTreeView));
+    context.subscriptions.push(connectAlbumTreeView(albumTreeView));
     context.subscriptions.push(connectTrackTreeView(trackTreeView));
     context.subscriptions.push(controller);
     context.subscriptions.push(spotifyStatus);

--- a/src/isAlbum.ts
+++ b/src/isAlbum.ts
@@ -1,0 +1,5 @@
+import { Album, Playlist } from "./state/state";
+
+export const isAlbum = (list?: Playlist | Album): list is Album => {
+  return !!list && ("album" in list);
+};

--- a/src/lyrics/lyrics.ts
+++ b/src/lyrics/lyrics.ts
@@ -29,14 +29,14 @@ interface Song {
     title: string,
     geniusPath?: string,
     /**
-     * String similarity score for the song. 
+     * String similarity score for the song.
      */
     similarity?: number
 }
 
 type V3SongsResponse = {
-    songs?: Song[]
-}
+    songs?: Song[];
+};
 
 export class LyricsController {
     private static lyricsContentProvider = new TextContentProvider();

--- a/src/reducers/root-reducer.ts
+++ b/src/reducers/root-reducer.ts
@@ -1,6 +1,8 @@
 import {
     Action,
+    ALBUM_LOAD_ACTION,
     PLAYLISTS_LOAD_ACTION,
+    SELECT_ALBUM_ACTION,
     SELECT_PLAYLIST_ACTION,
     SELECT_TRACK_ACTION,
     SIGN_IN_ACTION,
@@ -9,6 +11,7 @@ import {
     UPDATE_STATE_ACTION
 } from '../actions/common';
 import { log } from '../info/info';
+import { isAlbum } from '../isAlbum';
 import { DEFAULT_STATE, DUMMY_PLAYLIST, ISpotifyStatusState } from '../state/state';
 
 export function update<T>(obj: T, propertyUpdate: Partial<T>): T {
@@ -35,9 +38,19 @@ export default function (state: ISpotifyStatusState, action: Action): ISpotifySt
             playlists: (action.playlists && action.playlists.length) ? action.playlists : [DUMMY_PLAYLIST]
         });
     }
+    if (action.type === ALBUM_LOAD_ACTION) {
+        return update(state, {
+            albums: action.albums
+        });
+    }
+    if (action.type === SELECT_ALBUM_ACTION) {
+        return update(state, {
+            selectedList: action.album
+        });
+    }
     if (action.type === SELECT_PLAYLIST_ACTION) {
         return update(state, {
-            selectedPlaylist: action.playlist
+            selectedList: action.playlist
         });
     }
     if (action.type === SELECT_TRACK_ACTION) {
@@ -47,7 +60,10 @@ export default function (state: ISpotifyStatusState, action: Action): ISpotifySt
     }
     if (action.type === TRACKS_LOAD_ACTION) {
         return update(state, {
-            tracks: state.tracks.set(action.playlist.id, action.tracks)
+            tracks: state.tracks.set(
+                isAlbum(action.list) ? action.list.album.id : action.list.id,
+                action.tracks
+            )
         });
     }
     return state;

--- a/src/spotify/linux-spotify-client.ts
+++ b/src/spotify/linux-spotify-client.ts
@@ -252,7 +252,7 @@ export class LinuxSpotifyClient extends OsAgnosticSpotifyClient implements Spoti
                 isRunning: true
             };
             return result;
-        } catch (ignored) { log(ignored) }
+        } catch (ignored) { log(ignored); }
         return Promise.reject<ISpotifyStatusStatePartial>(`Spotify isn't running`);
     }
 

--- a/src/state/state.ts
+++ b/src/state/state.ts
@@ -1,7 +1,7 @@
-import { Playlist, Track } from '@vscodespotify/spotify-common/lib/spotify/consts';
+import { Playlist, Track, Album } from '@vscodespotify/spotify-common/lib/spotify/consts';
 import { Map } from 'immutable';
 
-export { Playlist, Track };
+export { Playlist, Track, Album };
 
 export interface ITrack {
     album: string;
@@ -62,9 +62,10 @@ export interface ISpotifyStatusStatePartial {
 export interface ISpotifyStatusState extends ISpotifyStatusStatePartial {
     loginState: ILoginState | null;
     playlists: Playlist[];
-    selectedPlaylist?: Playlist;
+    albums: Album[];
+    selectedList?: Playlist | Album;
     /**
-     * Map<Playlist.id>
+     * Map<Playlist.id | Album.album.id>
      */
     tracks: Map<Playlist['id'], Track[]>;
     selectedTrack: Track | null;
@@ -124,7 +125,8 @@ export const DEFAULT_STATE: ISpotifyStatusState = {
     loginState: null,
     context: void 0,
     playlists: [],
-    selectedPlaylist: void 0,
+    albums: [],
+    selectedList: undefined,
     tracks: Map(),
     selectedTrack: null
 };

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -14,14 +14,14 @@ let store: SpotifyStore;
 
 export function getStore(memento?: Memento) {
     if (!store) {
-        const notToPersistList = ['selectedTrack', 'selectedPlaylist'];
+        const notToPersistList: (keyof ISpotifyStatusState)[] = ['selectedTrack', 'selectedList'];
 
         const persistConfig: PersistConfig = {
             key: 'root',
             storage: memento ? createVscodeStorage(memento) : createDummyStorage(),
             transforms: [{
                 out: (val: any, key: string) => {
-                    if (~notToPersistList.indexOf(key)) {
+                    if (~notToPersistList.indexOf(key as keyof ISpotifyStatusState)) {
                         return null;
                     }
                     if (key === 'tracks') {
@@ -30,7 +30,7 @@ export function getStore(memento?: Memento) {
                     return val;
                 },
                 in: (val: any, key: string) => {
-                    if (~notToPersistList.indexOf(key)) {
+                    if (~notToPersistList.indexOf(key as keyof ISpotifyStatusState)) {
                         return null;
                     }
                     return val;


### PR DESCRIPTION
Hi, thanks for the awesome extension!

This PR adds a new view for the user's albums. Requires [ShyykoSerhiy/spotify-common#6](https://github.com/ShyykoSerhiy/spotify-common/pull/6) to be merged and released first, since it uses a new API to get albums.

Closes #80

![image](https://user-images.githubusercontent.com/16009897/100489632-3b900f00-317a-11eb-8c46-04ae7b48bead.png)
